### PR TITLE
getRealClass 1st argument must be string

### DIFF
--- a/lib/Doctrine/Search/UnitOfWork.php
+++ b/lib/Doctrine/Search/UnitOfWork.php
@@ -81,7 +81,7 @@ class UnitOfWork
         }
 
         $oid = spl_object_hash($entity);
-        $class = ClassUtils::getRealClass($entity);
+        $class = ClassUtils::getRealClass(get_class($entity));
         $this->scheduledForPersist[$class][$oid] = $entity;
 
         if ($this->evm->hasListeners(Events::postPersist)) {


### PR DESCRIPTION
Maybe I'm wrong but the first argument of ClassUtils::getRealClass() should be string (class name) instead of object. In every way there was a problem with persisting entities before.
